### PR TITLE
Fix "expected declaration specifiers or '...' before string constant" build issues

### DIFF
--- a/src/ts3init_module.c
+++ b/src/ts3init_module.c
@@ -14,6 +14,7 @@
  */
 
 #include <linux/kernel.h>
+#include <linux/module.h>
 #include <linux/netfilter/x_tables.h>
 
 /* defined in ts3init_match.c */


### PR DESCRIPTION
Depending on the kernel sources, including **linux/module.h** is necessary to build the netfilter module. Please refer to *[TeamSpeak Community Forums #127782](http://forum.teamspeak.com/threads/127782)* for the bug report and more information.