### PR TITLE
Fix compile errors on Debian 7.x

### DIFF
--- a/src/ts3init_match.c
+++ b/src/ts3init_match.c
@@ -13,6 +13,7 @@
  */
 
 #include <linux/kernel.h>
+#include <linux/module.h>
 #include <linux/netfilter/x_tables.h>
 #include <linux/skbuff.h>
 #include <linux/ip.h>


### PR DESCRIPTION
Compile the module on Debian 7.x fails as described in issue #4.