### PR TITLE
Fix "unknown field" errors when using designated initializer

### DIFF
--- a/src/ts3init_match.c
+++ b/src/ts3init_match.c
@@ -29,7 +29,7 @@
 
 /* Magic number of a TS3INIT packet. */
 static const struct ts3_init_header_tag ts3init_header_tag_signature =
-    { .tag8 = {'T', 'S', '3', 'I', 'N', 'I', 'T', '1'} };
+    {{ .tag8 = {'T', 'S', '3', 'I', 'N', 'I', 'T', '1'} }};
 
 
 struct ts3_init_checked_client_header_data


### PR DESCRIPTION
Older GCC versions will raise errors like this when trying to compile:

```
ts3init_match.c:31: error: unknown field ‘tag8’ specified in initializer
ts3init_match.c:31: warning: missing braces around initializer
ts3init_match.c:31: warning: (near initialization for ‘ts3init_header_tag_signature.<anonymous>.tag8’)
```